### PR TITLE
docs: OpenAPIを実装に同期・決定ログ追記（追記3/4）・api/ を ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,7 @@ config/minio/config/
 config/server/nginx/logs/
 config/docs/server/
 
+# Exclude PHP Laravel API project
+/api/
+
 

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -118,6 +118,9 @@ services:
       - "8888:8080"
     volumes:
       - ./docs:/usr/share/nginx/html/docs
+      - ./server/nginx/swagger-ui/conf:/etc/nginx/conf.d
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - URL=./docs/openapi.yml
 

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       - "8888:8080"
     volumes:
       - ./docs:/usr/share/nginx/html/docs
-      - ./server/nginx/swagger-ui/conf:/etc/nginx/conf.d
+      - ./server/nginx/swagger-ui/templates/default.conf.template:/etc/nginx/templates/default.conf.template:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:

--- a/config/docs/CHANGES-2025-08-12.md
+++ b/config/docs/CHANGES-2025-08-12.md
@@ -1,0 +1,47 @@
+# 変更概要（2025-08-12）
+
+- 目的: `express-rest-api` から Swagger 提供を切り離し、`config`（Swagger UI + Nginx）で提供。同一オリジン化で CORS を不要化し、OpenAPI の不整合を是正。
+
+## 1) express-rest-api（アプリ本体）
+- Swagger 提供コードを削除
+  - 削除: `src/config/swagger.ts`
+  - 変更: `src/main.ts` から `setupSwagger` と関連ログを除去
+- ポート変更: 既定 `8080` → `18081`
+- 依存整理: `swagger-ui-express`, `yamljs`, `@types/*` を `package.json` から削除
+
+## 2) config（インフラ・ドキュメント提供）
+- Swagger UI（Nginx）で `/api` を Express へリバースプロキシ
+  - 追加: `server/nginx/swagger-ui/templates/default.conf.template`
+    - `location /api/ { proxy_pass http://host.docker.internal:18081/api/; ... }`
+  - 変更: `docker-compose.yml`
+    - `lh_react_swagger-ui` にテンプレートをマウント
+    - `extra_hosts: ["host.docker.internal:host-gateway"]` を追加
+- OpenAPI の `servers` を相対パス化
+  - 変更: `docs/openapi.yml` → `servers.default: /api`
+
+## 3) OpenAPI 仕様の整合性修正
+- `PUT /items/{itemId}` にパスパラメータ定義を追加
+  - 変更: `docs/paths/items/itemId/index.yml`
+- パラメータ名の大小文字不一致を解消
+  - 変更: `docs/params/ItemId.yml` → `name: itemId`（小文字に統一）
+
+## 4) Git 管理
+- ルート単一リポジトリに統合（`config` と `express-rest-api`）
+  - 追加: ルート `.gitignore`（データ/ログ/`node_modules` 等を除外）
+  - リモート: `somadevfat/escsite-express-backend` に `main` / `develop` / `feature/nginx-proxy-express` を push
+
+---
+
+## 実行方法（再掲）
+- アプリ起動（:18081）
+  - `cd express-rest-api && npm run dev`
+- Swagger UI（:8888）
+  - `docker compose -f config/docker-compose.yml up -d lh_react_swagger-ui`
+- 動作確認
+  - `curl 'http://localhost:8888/api/items?limit=20&page=1'`
+  - `curl 'http://localhost:8888/api/items/2'`
+  - `curl -X PUT 'http://localhost:8888/api/items/2' -H 'Content-Type: application/json' --data-raw '{"name":"商品","price":120,"content":"商品詳細！"}'`
+
+## 補足
+- 同一オリジン（:8888配下）で `/api` を提供するため、ブラウザCORSは不要。
+- 404 の場合、`itemId` に実在 ID（例: `1..5`）を指定。

--- a/config/docs/openapi.yml
+++ b/config/docs/openapi.yml
@@ -8,7 +8,7 @@ servers:
     description: URL of the server
     variables:
       server:
-        default: http://localhost:8080/api
+        default: /api
 paths:
   # 認証
   /auth/signin:

--- a/config/docs/params/ItemId.yml
+++ b/config/docs/params/ItemId.yml
@@ -1,8 +1,8 @@
 in: path
-name: ItemId
-description: ユーザID
+name: itemId
+description: 商品ID
 required: true
 schema:
   type: integer
-  description: ユーザID
+  description: 商品ID
   example: 1

--- a/config/docs/paths/items/itemId/index.yml
+++ b/config/docs/paths/items/itemId/index.yml
@@ -18,6 +18,8 @@ put:
     - items
   summary: 商品更新
   description: 商品更新
+  parameters:
+    - $ref: ../../../params/ItemId.yml
   requestBody:
     description: 商品更新
     required: true

--- a/config/server/nginx/swagger-ui/conf/default.conf
+++ b/config/server/nginx/swagger-ui/conf/default.conf
@@ -1,0 +1,28 @@
+server {
+  listen 8080;
+  server_name localhost;
+
+  root /usr/share/nginx/html;  # swagger-ui の静的配信場所
+  index index.html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  # OpenAPIファイルを同一オリジンで配信
+  location /docs/ {
+    alias /usr/share/nginx/html/docs/;
+  }
+
+  # /api を Express へリバースプロキシ（Linuxでは host.docker.internal を extra_hosts で解決）
+  location /api/ {
+    proxy_pass http://host.docker.internal:18081/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}
+
+

--- a/config/server/nginx/swagger-ui/templates/default.conf.template
+++ b/config/server/nginx/swagger-ui/templates/default.conf.template
@@ -1,3 +1,6 @@
+# Custom default.conf.template for swaggerapi/swagger-ui
+# Generates /etc/nginx/conf.d/default.conf at container start
+
   types {
     text/plain yaml;
     text/plain yml;
@@ -41,7 +44,7 @@
       include templates/embedding.conf;
     }
 
-    # Proxy /api to Express (keeps /api prefix)
+    # Reverse proxy for Express API running on the host (Linux: host-gateway)
     location /api/ {
       proxy_pass http://host.docker.internal:18081/api/;
       proxy_http_version 1.1;

--- a/express-rest-api/src/main.ts
+++ b/express-rest-api/src/main.ts
@@ -18,7 +18,7 @@ async function startApplication(): Promise<void> {
   try {
     // Expressアプリケーションの作成
     const app = express();
-    const port = process.env.PORT || 8080;
+    const port = process.env.PORT || 18081;
 
     // 基本的なミドルウェアの設定
     app.use(express.json());

--- a/セットアップ.md
+++ b/セットアップ.md
@@ -1,0 +1,47 @@
+# まだなら
+npm init -y
+
+# 正しいパッケージ名でインストール
+npm i express
+npm i -D typescript tsx @types/node @types/express
+
+# TypeScript 初期化（typescript を入れた後に実行）
+npx tsc --init --rootDir src --outDir dist --esModuleInterop --resolveJsonModule --strict
+
+# 動作確認（バージョン表示）
+npx tsc --version
+
+# openapiでバリデーションできるようにする
+npm i express-openapi-validator
+
+# swager
+npm i cors && npm i -D @types/cors
+
+# pkg丹生行き
+  "start": "node dist/index.js",
+  "dev": "tsx watch src/index.ts"
+
+# testライブラリ
+npm i -D vitest supertest @types/supertest
+
+# コモンからESへ
+
+```
+{
+  // Visit https://aka.ms/tsconfig to read more about this file
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true
+  }
+}
+```
+
+cd /home/soma/workspace/ec-backend && docker compose -f config/docker-compose.yml up -d lh_react_swagger-ui
+
+cd /home/soma/workspace/ec-backend/express-rest-api && npm run dev


### PR DESCRIPTION
- docs: /auth/signup 有効化、/items/{ItemId} に統一、レスポンス定義の $ref 統一
- decisions: 2025-08-12-put-items-spec-fix.md に追記3/追記4
- .gitignore: /api/ を除外

確認ポイント:
- Swagger UI で /my/user, /items POST のスキーマ参照が components に統一されていること
- 再バンドル結果の整合（swagger-cli validate は Node 用に警告ありだが API 利用上は問題なし）