### PR TITLE
Prisma認証へ移行（password_hash追加・PrismaAuthRepository・seed）

### DIFF
--- a/express-rest-api/package-lock.json
+++ b/express-rest-api/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.13.0",
+        "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
@@ -19,6 +20,7 @@
         "zod": "^4.0.17"
       },
       "devDependencies": {
+        "@types/bcrypt": "^6.0.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jest": "^29.5.12",
@@ -1196,6 +1198,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1710,6 +1722,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -4560,12 +4586,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/express-rest-api/package.json
+++ b/express-rest-api/package.json
@@ -18,6 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "@prisma/client": "^6.13.0",
+    "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
@@ -27,6 +28,7 @@
     "zod": "^4.0.17"
   },
   "devDependencies": {
+    "@types/bcrypt": "^6.0.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jest": "^29.5.12",

--- a/express-rest-api/prisma/migrations/20250812_add_password_hash_nullable/migration.sql
+++ b/express-rest-api/prisma/migrations/20250812_add_password_hash_nullable/migration.sql
@@ -1,0 +1,5 @@
+-- Add password_hash column as nullable to existing users table
+ALTER TABLE `users`
+  ADD COLUMN `password_hash` VARCHAR(191) NULL;
+
+

--- a/express-rest-api/prisma/schema.prisma
+++ b/express-rest-api/prisma/schema.prisma
@@ -10,14 +10,15 @@ generator client {
 }
 
 datasource db {
-  provider = "mysql"
-  url      = env("DATABASE_URL")
+  provider          = "mysql"
+  url               = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
 model User {
   id                Int       @id @default(autoincrement())
   email             String    @unique
+  passwordHash      String?   @map("password_hash")
   emailVerifiedAt   DateTime? @map("email_verified_at")
   emailReissueToken String?   @map("email_reissue_token")
   isAdmin           Boolean   @default(false) @map("is_admin")
@@ -26,7 +27,7 @@ model User {
   createdBy         Int       @map("created_by")
   updatedBy         Int       @map("updated_by")
 
-  carts             Cart[]
+  carts Cart[]
 
   @@map("users")
 }
@@ -42,7 +43,7 @@ model Item {
   createdBy Int      @map("created_by")
   updatedBy Int      @map("updated_by")
 
-  carts     Cart[]
+  carts Cart[]
 
   @@map("items")
 }
@@ -57,8 +58,8 @@ model Cart {
   createdBy Int      @map("created_by")
   updatedBy Int      @map("updated_by")
 
-  user      User     @relation(fields: [userId], references: [id])
-  item      Item     @relation(fields: [itemId], references: [id])
+  user User @relation(fields: [userId], references: [id])
+  item Item @relation(fields: [itemId], references: [id])
 
   @@index([userId])
   @@index([itemId])

--- a/express-rest-api/src/config/container.ts
+++ b/express-rest-api/src/config/container.ts
@@ -20,6 +20,7 @@ import { PrismaUserRepository } from '../infrastructure/repositories/prismaUserR
 import { PrismaCartRepository } from '../infrastructure/repositories/prismaCartRepository';
 import { IAuthRepository } from '../domain/repositories/authRepository';
 import { InMemoryAuthRepository } from '../infrastructure/repositories/inMemoryAuthRepository';
+import { PrismaAuthRepository } from '../infrastructure/repositories/prismaAuthRepository';
 import { AuthUsecase } from '../application/usecases/authUsecase';
 import { AuthController } from '../interfaces/controllers/authController';
 
@@ -57,7 +58,7 @@ export class Container {
     this.itemRepository = usePrisma ? new PrismaItemRepository() : new InMemoryItemRepository();
     this.userRepository = usePrisma ? new PrismaUserRepository() : new InMemoryUserRepository();
     this.cartRepository = usePrisma ? new PrismaCartRepository() : new InMemoryCartRepository();
-    this.authRepository = new InMemoryAuthRepository();
+    this.authRepository = usePrisma ? new PrismaAuthRepository() : new InMemoryAuthRepository();
 
     // Application Layer
     this.itemUsecase = new ItemUsecase(this.itemRepository);

--- a/express-rest-api/src/infrastructure/prisma/seed.ts
+++ b/express-rest-api/src/infrastructure/prisma/seed.ts
@@ -1,12 +1,15 @@
 import { getPrismaClient } from './client';
+import bcrypt from 'bcrypt';
 
 export async function ensurePrismaSeed(): Promise<void> {
   const prisma = getPrismaClient();
   const users = await prisma.user.count();
   if (users === 0) {
+    const passwordHash = await bcrypt.hash('pass', 10);
     await prisma.user.create({
       data: {
         email: 'admin@lh.sandbox',
+        passwordHash,
         isAdmin: true,
         createdBy: 1,
         updatedBy: 1,

--- a/express-rest-api/src/infrastructure/repositories/prismaAuthRepository.ts
+++ b/express-rest-api/src/infrastructure/repositories/prismaAuthRepository.ts
@@ -1,0 +1,50 @@
+import bcrypt from 'bcrypt';
+import { IAuthRepository } from '../../domain/repositories/authRepository';
+import { getPrismaClient } from '../prisma/client';
+import { signAuthToken } from '../../config/jwt';
+
+export class PrismaAuthRepository implements IAuthRepository {
+  private prisma = getPrismaClient();
+
+  async signin(email: string, password: string, admin = false): Promise<string> {
+    const user = await this.prisma.user.findUnique({ where: { email } });
+    if (!user || !user.passwordHash) {
+      throw new Error('Invalid credentials');
+    }
+    const ok = await bcrypt.compare(password, user.passwordHash);
+    if (!ok) {
+      throw new Error('Invalid credentials');
+    }
+    if (admin && !user.isAdmin) {
+      throw new Error('Invalid credentials');
+    }
+    return signAuthToken({ sub: String(user.id), email: user.email, isAdmin: !!user.isAdmin });
+  }
+
+  async signout(_token?: string): Promise<void> {
+    return;
+  }
+
+  async signup(email: string, password: string): Promise<string> {
+    const exists = await this.prisma.user.findUnique({ where: { email } });
+    if (exists) {
+      throw new Error('User already exists');
+    }
+    const passwordHash = await bcrypt.hash(password, 10);
+    const now = new Date();
+    const created = await this.prisma.user.create({
+      data: {
+        email,
+        passwordHash,
+        isAdmin: false,
+        createdAt: now,
+        updatedAt: now,
+        createdBy: 1,
+        updatedBy: 1,
+      },
+    });
+    return signAuthToken({ sub: String(created.id), email: created.email, isAdmin: false });
+  }
+}
+
+

--- a/express-rest-api/src/main.ts
+++ b/express-rest-api/src/main.ts
@@ -10,6 +10,7 @@ import rateLimit from 'express-rate-limit';
 import { loadEnv } from './config/env';
 import { Container } from './config/container';
 import { createApiRoutes } from './interfaces/routes/itemRoutes';
+import { ensurePrismaSeed } from './infrastructure/prisma/seed';
 
 // 環境変数の読み込み (.env.development があれば優先して読み込む)
 loadEnv();
@@ -54,6 +55,11 @@ export function createApp(): Express {
  */
 async function startApplication(): Promise<void> {
   try {
+    const useDb = process.env.USE_DB === 'true';
+    if (useDb) {
+      await ensurePrismaSeed();
+    }
+
     const app = createApp();
     const port = process.env.PORT || 18081;
     // サーバー起動


### PR DESCRIPTION
目的: 本番仕様の認証に移行（DB連携＋安全なパスワード管理）

- users に password_hash を追加（ベースライン戦略）
  - 既存DBをベースライン登録（v1は適用済みとして履歴整合）
  - v2: password_hash を nullable で追加（移行安全性のため）
  - 将来 v3: password_hash を非NULLへ昇格予定（全件ハッシュ移行後）
- PrismaAuthRepository を実装し、signup/signin を DB照合（bcrypt）に変更
- USE_DB=true の場合に DI を PrismaAuthRepository に切り替え
- seed 起動（ensurePrismaSeed）で管理者をハッシュで投入

動作確認:
- admin/signin: 200 OK + JWT
- signup → signin: 200 OK + JWT
- 想定異常系: 401/400 を確認済み

補足:
- v2 は `prisma db execute` で適用済み（履歴は `migrate resolve` 済み）
- 本番適用時は `migrate deploy` を基本とし、今回の手動適用はRunbookに記録します。